### PR TITLE
Unhandled exceptions in the underlying service are now bubbled up

### DIFF
--- a/OnionConsole.AppService/Program.cs
+++ b/OnionConsole.AppService/Program.cs
@@ -7,19 +7,8 @@ namespace OnionConsole.AppService
     {
         static void Main(string[] args)
         {
-            try
-            {
-                var cloudServiceHelper = new CloudServiceWrapper(Directory.GetCurrentDirectory());
-                cloudServiceHelper.StartCloudService();
-            }
-            catch (Exception e)
-            {
-                Console.WriteLine($"Error starting Role {e.Message}");
-            }
-
-
+            var cloudServiceHelper = new CloudServiceWrapper(Directory.GetCurrentDirectory());
+            cloudServiceHelper.StartCloudService();
         }
     }
-
-
 }

--- a/OnionConsole/CloudServiceWrapper.cs
+++ b/OnionConsole/CloudServiceWrapper.cs
@@ -68,16 +68,14 @@ namespace OnionConsole
 
         private void RunRole(Type roleType)
         {
-            try
-            {
-                // does this also apply to web roles??
-                if (!roleType.Name.Contains("Worker"))
+            // does this also apply to web roles??
+            if (!roleType.Name.Contains("Worker"))
             {
                 Console.WriteLine("Unable to run a non worker role");
                 return;
             }
-            
-            _workerRole = (RoleEntryPoint)Activator.CreateInstance(roleType);
+
+            _workerRole = (RoleEntryPoint) Activator.CreateInstance(roleType);
 
             if (!_workerRole.OnStart())
             {
@@ -85,27 +83,20 @@ namespace OnionConsole
                 return;
             }
 
-                Console.WriteLine("Role is starting for '{0}'", roleType);
-                _workerRole.Run();
-
-            }
-            catch (Exception ex)
-            {
-                Console.WriteLine("Unable to Run Role" + ex.GetBaseException());
-                _workerRole.OnStop();
-            }
+            Console.WriteLine("Role is starting for '{0}'", roleType);
+            _workerRole.Run();
         }
-
 
         public void StartCloudService()
         {
             var roleToRun = FindRoleEntryTypes()?.FirstOrDefault();
-            if (roleToRun != null)
+            if (roleToRun == null)
             {
-                Console.WriteLine($"Run Role Called for Role {roleToRun?.FullName}");
-                RunRole(FindRoleEntryTypes().FirstOrDefault());
-
+                throw new InvalidOperationException("Could not find role entry point");
             }
+
+            Console.WriteLine($"Run Role Called for Role {roleToRun.FullName}");
+            RunRole(roleToRun);
         }
     }
 }


### PR DESCRIPTION
If an underlying service throws an exception a few things should happen;
 - The full exception (ie including stack trace) should be made visible
 - The process exit code should be non-zero
 - OnStop should *not* be called (https://docs.microsoft.com/en-us/azure/cloud-services/cloud-services-role-lifecycle-dotnet)